### PR TITLE
Umwandlung eines Dokuments aus Pubmed in BioC xml im DOM Format

### DIFF
--- a/PubMedtoBioCinDOM.py
+++ b/PubMedtoBioCinDOM.py
@@ -1,0 +1,6 @@
+# coding: utf-8
+import requests
+import xml.dom.minidom
+PMID = 29171663 #exemplary Pubmed ID
+req = requests.get('https://www.ncbi.nlm.nih.gov/research/bionlp/RESTful/pubmed.cgi/BioC_xml/'+str(PMID)+'/unicode') #returns the PubMed in BioC xml format
+dom = xml.dom.minidom.parseString(req.text) #dom contains the BioC xml file in DOM format


### PR DESCRIPTION
Dieses Pythonskript wandelt ein Pubmed Dokument zu einer bestimmten PubMed ID in BioC xml im DOM format um.
Die Pubmed ID wird (natürlich noch) handschriftlich eingetragen. Variable `dom` enthält als DOM Objekt das Dokoment in BioC xml.